### PR TITLE
[BUGFIX] Do not query processed files which are not handled by the driver

### DIFF
--- a/Classes/CacheControl/RemoteObjectUpdater.php
+++ b/Classes/CacheControl/RemoteObjectUpdater.php
@@ -63,7 +63,7 @@ class RemoteObjectUpdater
                 );
             }
         }
-        
+
         return [$data];
     }
 
@@ -91,11 +91,13 @@ class RemoteObjectUpdater
         array $configuration
     ) {
         // If processFile was unsuccessful, getFileInfoByIdentifier will throw an error
-        if (! $processedFile->exists()) {
+        if (!$processedFile->exists()
+            || !FalS3\Utility\RemoteObjectUtility::resolveClientForStorage($processedFile->getStorage())
+        ) {
             return;
         }
 
-        $fileInfo = $driver->getFileInfoByIdentifier($processedFile->getIdentifier());
+        $fileInfo = $processedFile->getStorage()->getFileInfoByIdentifier($processedFile->getIdentifier());
 
         if (is_array($fileInfo)
             && array_key_exists('mtime', $fileInfo)

--- a/Classes/CacheControl/RemoteObjectUpdater.php
+++ b/Classes/CacheControl/RemoteObjectUpdater.php
@@ -90,6 +90,11 @@ class RemoteObjectUpdater
         $taskType,
         array $configuration
     ) {
+        // If processFile was unsuccessful, getFileInfoByIdentifier will throw an error
+        if (! $processedFile->exists()) {
+            return;
+        }
+
         $fileInfo = $driver->getFileInfoByIdentifier($processedFile->getIdentifier());
 
         if (is_array($fileInfo)

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -803,11 +803,12 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
      * buffer before. Will be taken care of by the Storage.
      *
      * @param string $identifier
+     *
      * @return void
      */
     public function dumpFileContents($identifier)
     {
-        echo $this->getFileContents($identifier);
+        readfile($this->getStreamWrapperPath($this->canonicalizeAndCheckFileIdentifier($identifier)), 0);
     }
 
     /**

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -699,7 +699,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
     {
         $fileIdentifier = $this->canonicalizeAndCheckFileIdentifier($fileIdentifier);
 
-        return file_get_contents($this->getStreamWrapperPath($fileIdentifier));
+        return readfile($this->getStreamWrapperPath($fileIdentifier));
     }
 
     /**

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -699,7 +699,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
     {
         $fileIdentifier = $this->canonicalizeAndCheckFileIdentifier($fileIdentifier);
 
-        return readfile($this->getStreamWrapperPath($fileIdentifier));
+        return file_get_contents($this->getStreamWrapperPath($fileIdentifier));
     }
 
     /**

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -769,8 +769,9 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
 
         copy($path, $temporaryFilePath);
 
-        // add to temporary files to be cleanup after __destruct correctly
-        $this->temporaryFiles[$fileIdentifier] = $temporaryFilePath;
+        if (!$writable) {
+            $this->temporaryFiles[$fileIdentifier] = $temporaryFilePath;
+        }
 
         return $temporaryFilePath;
     }

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -1131,12 +1131,11 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
                 continue;
             }
             $iterator->next();
-            $file = $this->getFileInfoByIdentifier($entry);
             if(! $this->applyFilterMethodsToDirectoryItem(
                     $filterMethods,
-                    $file['name'],
-                    $file['identifier'],
-                    $this->getParentFolderIdentifierOfIdentifier($file['identifier']))
+                    $entry,
+                    $entry,
+                    $this->getParentFolderIdentifierOfIdentifier($entry))
             ) {
                 unset($directoryEntries[$entry]);
             }

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -558,9 +558,9 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
      */
     public function hash($fileIdentifier, $hashAlgorithm)
     {
+        echo 'Hashing file: ' . $fileIdentifier . ' (This may take a while...)';
         $fileIdentifier = $this->canonicalizeAndCheckFileIdentifier($fileIdentifier);
         $path = $this->getStreamWrapperPath($fileIdentifier);
-
         switch ($hashAlgorithm) {
             case 'sha1':
                 $hash = sha1_file($path);

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -769,9 +769,8 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
 
         copy($path, $temporaryFilePath);
 
-        if (!$writable) {
-            $this->temporaryFiles[$fileIdentifier] = $temporaryFilePath;
-        }
+        // add to temporary files to be cleanup after __destruct correctly
+        $this->temporaryFiles[$fileIdentifier] = $temporaryFilePath;
 
         return $temporaryFilePath;
     }

--- a/Classes/MetaData/RecordMonitor.php
+++ b/Classes/MetaData/RecordMonitor.php
@@ -58,7 +58,7 @@ class RecordMonitor
             || (
                 $file !== null
                 && $file->getType() !== AbstractFile::FILETYPE_IMAGE
-                && $file->getStorage()->getDriverType() !== AmazonS3Driver::DRIVER_KEY
+                || $file->getStorage()->getDriverType() !== AmazonS3Driver::DRIVER_KEY
             )
         ) {
             return;


### PR DESCRIPTION
Before trying to update S3 meta data, we need to ensure, the the
processed file is actually on an S3 storage.

We also need to make sure to resolve the file info with the driver
attached to the processed file storage, not the one passed, which is the
one from the original file, which could be a different one.