### PR TITLE
[BUGFIX] Do not query processed files which are not handled by the driver

### DIFF
--- a/Classes/CacheControl/RemoteObjectUpdater.php
+++ b/Classes/CacheControl/RemoteObjectUpdater.php
@@ -63,7 +63,7 @@ class RemoteObjectUpdater
                 );
             }
         }
-        
+
         return [$data];
     }
 
@@ -91,11 +91,13 @@ class RemoteObjectUpdater
         array $configuration
     ) {
         // If processFile was unsuccessful, getFileInfoByIdentifier will throw an error
-        if (! $processedFile->exists()) {
+        if (!$processedFile->exists()
+            || !FalS3\Utility\RemoteObjectUtility::resolveClientForStorage($processedFile->getStorage())
+        ) {
             return;
         }
 
-        $fileInfo = $driver->getFileInfoByIdentifier($processedFile->getIdentifier());
+        $fileInfo = $processedFile->getStorage()->getFileInfoByIdentifier($processedFile->getIdentifier());
 
         if (is_array($fileInfo)
             && array_key_exists('mtime', $fileInfo)


### PR DESCRIPTION
Before trying to update S3 meta data, we need to ensure, the the
processed file is actually on an S3 storage.

We also need to make sure to resolve the file info with the driver
attached to the processed file storage, not the one passed, which is the
one from the original file, which could be a different one.