### PR TITLE
[BUGFIX] Disable remote cache control feature

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -614,6 +614,9 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
         echo 'Hashing file: ' . $fileIdentifier . ' (This may take a while...)';
         $fileIdentifier = $this->canonicalizeAndCheckFileIdentifier($fileIdentifier);
         $path = $this->getStreamWrapperPath($fileIdentifier);
+        if (isset($this->temporaryFiles[$fileIdentifier])) {
+            $path = $this->temporaryFiles[$fileIdentifier];
+        }
         switch ($hashAlgorithm) {
             case 'sha1':
                 $hash = sha1_file($path);

--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -354,10 +354,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
     {
         $fileIdentifier = $this->canonicalizeAndCheckFileIdentifier($fileIdentifier);
 
-        $path = rtrim(
-            $this->getStreamWrapperPath($fileIdentifier),
-            '/'
-        );
+        $path = $this->getStreamWrapperPath($fileIdentifier);
 
         if (!array_key_exists($path, $this->fileExistsCache)) {
             $this->fileExistsCache[$path] = is_file($path);
@@ -376,10 +373,7 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
     {
         $folderIdentifier = $this->canonicalizeAndCheckFolderIdentifier($folderIdentifier);
 
-        $path = rtrim(
-            $this->getStreamWrapperPath($folderIdentifier),
-            '/'
-        );
+        $path = $this->getStreamWrapperPath($folderIdentifier);
 
         if (!array_key_exists($path, $this->folderExistsCache)) {
             $this->folderExistsCache[$path] = is_dir($path);
@@ -1320,6 +1314,11 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
      */
     protected function flushCacheEntriesForFolder($folderIdentifier)
     {
+        // Files and/or folders have changed
+        // Ensure correct results for all following API calls by flushing the runtime cache as well
+        $this->fileExistsCache = [];
+        $this->folderExistsCache = [];
+
         $folderIdentifier = $this->canonicalizeAndCheckFolderIdentifier($folderIdentifier);
         $path = $this->getStreamWrapperPath($folderIdentifier);
 

--- a/Classes/Utility/RemoteObjectUtility.php
+++ b/Classes/Utility/RemoteObjectUtility.php
@@ -76,7 +76,7 @@ class RemoteObjectUtility
 
         if (array_key_exists($storageIdentifier, self::$driverConfigurations)) {
             $driverConfiguration = self::$driverConfigurations[$storageIdentifier];
-        } else if ($storage->getDriverType() === FalS3\Driver\AmazonS3Driver::DRIVER_KEY) {
+        } elseif ($storage->getDriverType() === FalS3\Driver\AmazonS3Driver::DRIVER_KEY) {
             $storageConfiguration = $storage->getConfiguration();
 
             if (array_key_exists('configurationKey', $storageConfiguration)) {
@@ -90,6 +90,16 @@ class RemoteObjectUtility
         }
 
         return $driverConfiguration;
+    }
+
+    /**
+     * @param Core\Resource\ResourceStorage $storage
+     *
+     * @return bool
+     */
+    public static function hasCacheControlDirectivesInStorage(Core\Resource\ResourceStorage $storage)
+    {
+        return !empty(self::resolveDriverConfigurationForStorage($storage)['cacheControl']);
     }
 
     /**

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -84,6 +84,11 @@ $signalSlotDispatcher->connect(
     'onPreFileProcess'
 );
 
+/*
+ * Disable this functionality for now as there are conceptual issues to be resolved
+ * namely that the cache control header meta data update causes the modification date
+ * of the remote file change, thus leading to an invalidation of all processed files.
+ *
 // cache control, trigger an update of remote objects if a changes is made locally (eg. by running the scheduler)
 $signalSlotDispatcher->connect(
     'TYPO3\\CMS\\Core\\Resource\\Index\\MetaDataRepository',
@@ -105,6 +110,7 @@ $signalSlotDispatcher->connect(
     'MaxServ\\FalS3\\CacheControl\\RemoteObjectUpdater',
     'onPostFileProcess'
 );
+*/
 
 $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['deployer']['configuration']['FalS3.yaml'] = array(
     'converter' => 'MaxServ\\FalS3\\Configuration\\ConfigurationConverter',


### PR DESCRIPTION
There is a considerable impact with adding cache control
headers to remote objects and that is that the modification time
will change of that object.

When performing this operation on files when meta data records are
changed within TYPO3, this leads to an update of the remote file,
directly invalidating all processed files, which are bound to the modification
date of the original file.

While trying to fix the causing errors, it was decided to better deactivate
this feature to avoid causing such issues