### PR TITLE
Add new hash algorithms for content hashes

### DIFF
--- a/Classes/Driver/AmazonS3Driver.php
+++ b/Classes/Driver/AmazonS3Driver.php
@@ -636,6 +636,17 @@ class AmazonS3Driver extends TYPO3\CMS\Core\Resource\Driver\AbstractHierarchical
             case 'md5':
                 $hash = md5($etag);
                 break;
+            case 'md5File':
+                $hash = $etag;
+                if (!preg_match('/^[a-f0-9]{32}$/', $etag)) {
+                    $localFile = $this->getFileForLocalProcessing($fileIdentifier, false);
+                    $hash = md5_file($localFile);
+                }
+                break;
+            case 'sha1File':
+                $localFile = $this->getFileForLocalProcessing($fileIdentifier, false);
+                $hash = sha1_file($localFile);
+                break;
             default:
                 throw new \RuntimeException('Hash algorithm ' . $hashAlgorithm . ' is not implemented.', 1329644451);
         }

--- a/Classes/Updates/Sha1Update.php
+++ b/Classes/Updates/Sha1Update.php
@@ -53,7 +53,7 @@ class Sha1Update extends AbstractUpdate
 
         // Check if there is a registry entry from a former run that may have been stopped
         $registry = GeneralUtility::makeInstance(Registry::class);
-        $registryEntry = $registry->get('falS3', 'Sha1Update');
+        $registryEntry = $registry->get('falS3', 'sha1Update');
         if ($registryEntry !== null) {
             return true;
         }


### PR DESCRIPTION
This patch adds two new hash algorithms `md5File` and `sha1File` to receive the hashes from the current file content. Existing hash algorithms `md5` and `sha1` still return a hash that is optimized for performance.